### PR TITLE
Fix/improve filecontents threading

### DIFF
--- a/ProjectLaminar.slnx
+++ b/ProjectLaminar.slnx
@@ -32,7 +32,9 @@
     <Project Path="src/Plugins/BasicFunctionality.Avalonia/BasicFunctionality.Avalonia.csproj" />
     <Project Path="src/Plugins/BasicFunctionality/BasicFunctionality.csproj" />
   </Folder>
-  <Folder Name="/tests/" />
+  <Folder Name="/tests/">
+    <File Path="tests/Directory.Build.props" />
+  </Folder>
   <Folder Name="/tests/Application/">
     <Project Path="tests/Application/Laminar.Domain.UnitTests/Laminar.Domain.UnitTests.csproj" />
     <Project Path="tests/Application/Laminar.Implementation.UnitTests/Laminar.Implementation.UnitTests.csproj" />

--- a/src/Application/Laminar.Contracts/Storage/IO/IFileContents.cs
+++ b/src/Application/Laminar.Contracts/Storage/IO/IFileContents.cs
@@ -19,10 +19,7 @@ public interface IFileContents : IDisposable, IValueSink<byte[]>
     /// </summary>
     public event EventHandler? ContentsChanged;
 
-    /// <summary>
-    /// Ensures that the file is up to date, waits for all read/write tasks to be complete and synced up.
-    /// </summary>
-    public void CheckAccess();
+    public Task WaitForPendingOperations();
     
     byte[] IValueSink<byte[]>.Value { set => Contents = value; }
 }

--- a/src/Application/Laminar.Contracts/Storage/IO/IFileSystem.cs
+++ b/src/Application/Laminar.Contracts/Storage/IO/IFileSystem.cs
@@ -20,6 +20,8 @@ public interface IFileSystem
     
     public Task WriteBytes(FileSystemPath path, byte[] bytes, CancellationToken cancellationToken = default);
 
+    public Task<byte[]> ReadBytesAsync(FileSystemPath path, CancellationToken cancellationToken = default);
+    
     public byte[] ReadBytes(FileSystemPath path);
     
     public long GetFileSize(FileSystemPath path);

--- a/src/Application/Laminar.Implementation/Storage/IO/FileContents.cs
+++ b/src/Application/Laminar.Implementation/Storage/IO/FileContents.cs
@@ -1,5 +1,6 @@
 using System.Runtime.InteropServices;
 using Laminar.Contracts.Storage.IO;
+using Laminar.Domain.Helpers;
 using Laminar.Domain.ValueObjects;
 using Microsoft.Extensions.Logging;
 
@@ -9,164 +10,234 @@ internal partial class FileContents : IFileContents
 {
     private const int ErrorSharingViolation = 32;
     private const int ErrorLockViolation = 33;
-    
-    private static readonly TimeSpan FileBusyWaitDuration = new(0, 0, 2);
-    
+
+    private static readonly TimeSpan FileBusyWaitDuration = TimeSpan.FromSeconds(2);
+
     private readonly IFileSystem _fileSystem;
-    private readonly CancellationTokenSource _cancelReadTokenSource = new();
-    private readonly CancellationTokenSource _cancelWriteTokenSource = new();
     private readonly IFileWatcher _fileWatcher;
     private readonly ILogger<FileContents> _logger;
-    
+
+    private readonly Lock _lock = new();
+    private readonly CancellationTokenSource _cts = new();
+
     private byte[] _contents = [];
-    private bool _readNextFileChange = true;
-    private Task? _writeTask;
-    private Task? _readTask;
+
+    private bool _pendingWrite;
+    private bool _pendingRead;
+    private bool _running;
+    private long _version;
+
+    private TaskCompletionSource _idleTcs = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
     public FileContents(IFileSystem fileSystem, FileSystemPath path, ILogger<FileContents> logger)
     {
-        _logger = logger;
         _fileSystem = fileSystem;
+        _logger = logger;
         Path = path;
 
-        if (!_fileSystem.Exists(Path))
+        if (!_fileSystem.Exists(path))
         {
-            _fileSystem.CreateFile(Path).Close();
+            _fileSystem.CreateFile(path).Close();
         }
         else
         {
-            InitiateReadAttempt().Wait();   
+            _contents = _fileSystem.ReadBytes(path);
         }
 
-        if (Path.Parent is not { } parent)
-        {
-            throw new Exception("File must have a parent path");
-        }
-        
-        _fileWatcher = fileSystem.CreateFileWatcher(parent, Path.NameAndExtension);
+        _idleTcs.TrySetResult();
+
+        var parent = path.Parent ?? throw new InvalidOperationException("File must have parent");
+
+        _fileWatcher = _fileSystem.CreateFileWatcher(parent, path.NameAndExtension);
         _fileWatcher.NotifyFilter = NotifyFilters.LastWrite;
         _fileWatcher.EnableRaisingEvents = true;
         _fileWatcher.Changed += FileChanged;
-    }
-    
-    public byte[] Contents
-    {
-        get => _contents;
-        set
-        {
-            if (_contents == value)
-            {
-                return;
-            }
-            
-            _contents = value;
-            ContentsChanged?.Invoke(this, EventArgs.Empty);
-
-            if (_writeTask is null || _writeTask.IsCompleted)
-            {
-                _writeTask = Task.Run(InitiateWrite);
-            }
-        }
     }
 
     public FileSystemPath Path { get; }
 
     public event EventHandler? ContentsChanged;
-    
-    public void CheckAccess()
-    {
-        if (_writeTask is not null && !_writeTask.IsCompleted)
-        {
-            _writeTask.Wait();
-        }
 
-        if (_readTask is not null && !_readTask.IsCompleted)
+    public byte[] Contents
+    {
+        get { lock (_lock) return _contents; }
+        set
         {
-            _readTask.Wait();
+            lock (_lock)
+            {
+                if (BytesHelper.Equals(_contents, value)) return;
+                _contents = value;
+                _version++;
+                _pendingWrite = true;
+                EnsureRunning();
+            }
+
+            ContentsChanged?.Invoke(this, EventArgs.Empty);
+        }
+    }
+
+    public Task WaitForPendingOperations()
+    {
+        lock (_lock)
+        {
+            return _idleTcs.Task;
         }
     }
 
     private void FileChanged(object? sender, FileSystemEventArgs e)
     {
-        if (e.FullPath != Path.ToString() || e.ChangeType != WatcherChangeTypes.Changed)
-        {
+        if (!e.FullPath.Equals(Path))
             return;
+
+        lock (_lock)
+        {
+            // Writes dominate.
+            // If we already intend to write, ignore external changes.
+            if (_pendingWrite)
+                return;
+
+            _pendingRead = true;
+            EnsureRunning();
         }
-        
-        if (!_readNextFileChange)
-        {
-            _readNextFileChange = true;
+    }
+
+    private void EnsureRunning()
+    {
+        if (_running)
             return;
+
+        _running = true;
+
+        if (_idleTcs.Task.IsCompleted)
+        {
+            _idleTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         }
 
-        if (_readTask is null || _readTask.IsCompleted)
-        {
-            _readTask = Task.Run(InitiateReadAttempt);
-        }
+        _ = Task.Run(RunAsync);
     }
-    
-    private async Task InitiateWrite()
-    {
-        var success = false;
-        var cancellationToken = _cancelWriteTokenSource.Token;
-        _readNextFileChange = false;
-        
-        while (!success && !cancellationToken.IsCancellationRequested)
-        {
-            try
-            {
-                await _fileSystem.WriteBytes(Path, _contents, cancellationToken);
-                success = true;
-            }
-            catch (IOException e)
-            {
-                await WaitIfFileBusyException(e, cancellationToken);
-            }
-        }
-    }
-    
-    private async Task InitiateReadAttempt()
-    {
-        var readSuccessful = false;
-        var cancellationToken = _cancelReadTokenSource.Token;
 
-        while (!readSuccessful && !cancellationToken.IsCancellationRequested)
+    private async Task RunAsync()
+    {
+        try
         {
-            try
+            while (!_cts.IsCancellationRequested)
             {
-                _contents = _fileSystem.ReadBytes(Path);
-                readSuccessful = true;
-                ContentsChanged?.Invoke(this, EventArgs.Empty);
+                bool doWrite;
+                bool doRead;
+
+                byte[] writeContents = [];
+                long readVersion = 0;
+
+                lock (_lock)
+                {
+                    doWrite = _pendingWrite;
+                    doRead = !doWrite && _pendingRead;
+
+                    if (!doWrite && !doRead)
+                    {
+                        _running = false;
+                        _idleTcs.TrySetResult();
+                        return;
+                    }
+
+                    if (doWrite)
+                    {
+                        _pendingWrite = false;
+                        writeContents = _contents;
+                    }
+                    else
+                    {
+                        _pendingRead = false;
+                        readVersion = _version;
+                    }
+                }
+
+                try
+                {
+                    if (doWrite)
+                    {
+                        await _fileSystem.WriteBytes(Path, writeContents, _cts.Token);
+                    }
+                    else if (doRead)
+                    {
+                        byte[] diskContents = await _fileSystem.ReadBytesAsync(Path, _cts.Token);
+
+                        bool changed = false;
+
+                        lock (_lock)
+                        {
+                            // Ignore stale reads if memory changed while reading
+                            if (readVersion != _version)
+                                continue;
+
+                            if (!BytesHelper.Equals(_contents, diskContents))
+                            {
+                                _contents = diskContents;
+                                changed = true;
+                            }
+                        }
+
+                        if (changed)
+                        {
+                            ContentsChanged?.Invoke(this, EventArgs.Empty);
+                        }
+                    }
+                }
+                catch (IOException ex) when (IsFileBusy(ex))
+                {
+                    LogFileIsBusy(Path, FileBusyWaitDuration.TotalMilliseconds);
+
+                    await Task.Delay(FileBusyWaitDuration, _cts.Token);
+
+                    // Re-queue intent
+                    lock (_lock)
+                    {
+                        if (doWrite)
+                        {
+                            _pendingWrite = true;
+                        }
+                        else if (doRead)
+                        {
+                            _pendingRead = true;
+                        }
+                    }
+                }
             }
-            catch (IOException e)
+        }
+        catch (OperationCanceledException)
+        {
+        }
+        finally
+        {
+            lock (_lock)
             {
-                await WaitIfFileBusyException(e, cancellationToken);
+                _running = false;
+                _idleTcs.TrySetCanceled();
             }
         }
     }
-    
+
     public void Dispose()
     {
-        _cancelReadTokenSource.Dispose();
-        _cancelWriteTokenSource.Dispose();
+        _cts.Cancel();
+
         _fileWatcher.Dispose();
+        _cts.Dispose();
+
+        lock (_lock)
+        {
+            _idleTcs.TrySetCanceled();
+        }
+
         GC.SuppressFinalize(this);
     }
 
-    private async Task WaitIfFileBusyException(IOException e, CancellationToken cancellationToken)
+    private static bool IsFileBusy(IOException e)
     {
-        int errorCode = Marshal.GetHRForException(e) & ((1 << 16) - 1);
-        if (errorCode is ErrorSharingViolation or ErrorLockViolation)
-        {
-            LogFileFileIsBusyWaitingMillisecondsBeforeTryingToAccessAgain(Path, FileBusyWaitDuration.TotalMilliseconds);
-            await Task.Delay(FileBusyWaitDuration, cancellationToken);   
-        }
-        else
-        {
-            throw new Exception("Unexpected error when accessing file", innerException: e);
-        }
+        int errorCode = Marshal.GetHRForException(e) & 0xFFFF;
+        return errorCode is ErrorSharingViolation or ErrorLockViolation;
     }
 
-    [LoggerMessage(LogLevel.Debug, "File '{filePath}' is busy. Waiting {waitDurationMs}ms before trying to access again")]
-    partial void LogFileFileIsBusyWaitingMillisecondsBeforeTryingToAccessAgain(FileSystemPath filePath, double waitDurationMs);
+    [LoggerMessage(LogLevel.Debug, "File '{filePath}' is busy. Waiting {waitDurationMs}ms before retry")]
+    partial void LogFileIsBusy(FileSystemPath filePath, double waitDurationMs);
 }

--- a/src/Application/Laminar.Implementation/Storage/IO/FileSystem.cs
+++ b/src/Application/Laminar.Implementation/Storage/IO/FileSystem.cs
@@ -87,8 +87,10 @@ internal partial class FileSystem(ILogger<IFileSystem> fileSystemLogger, ILogger
     public Task WriteBytes(FileSystemPath path, byte[] bytes, CancellationToken cancellationToken = default) 
         => File.WriteAllBytesAsync(path.ToString(), bytes, cancellationToken);
 
-    public byte[] ReadBytes(FileSystemPath path) 
-        => File.ReadAllBytes(path.ToString());
+    public Task<byte[]> ReadBytesAsync(FileSystemPath path, CancellationToken cancellationToken = default) 
+        => File.ReadAllBytesAsync(path.ToString(), cancellationToken);
+
+    public byte[] ReadBytes(FileSystemPath path) => File.ReadAllBytes(path.ToString());
 
     public long GetFileSize(FileSystemPath path)
         => new FileInfo(path.ToString()).Length;

--- a/src/PluginFramework/Directory.Build.props
+++ b/src/PluginFramework/Directory.Build.props
@@ -1,5 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="Current" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+﻿<Project ToolsVersion="Current" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
     <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)..\'))" />
 

--- a/tests/Application/Laminar.Domain.UnitTests/Helpers.UnitTests/BytesHelperTests.cs
+++ b/tests/Application/Laminar.Domain.UnitTests/Helpers.UnitTests/BytesHelperTests.cs
@@ -1,0 +1,6 @@
+namespace Laminar.Domain.UnitTests.Helpers.UnitTests;
+
+public class BytesHelperTests
+{
+    
+}

--- a/tests/Application/Laminar.Domain.UnitTests/Helpers.UnitTests/BytesHelperTests.cs
+++ b/tests/Application/Laminar.Domain.UnitTests/Helpers.UnitTests/BytesHelperTests.cs
@@ -1,6 +1,26 @@
+using Laminar.Domain.Helpers;
+
 namespace Laminar.Domain.UnitTests.Helpers.UnitTests;
 
 public class BytesHelperTests
 {
-    
+    [Fact]
+    public void ShouldMatchSuccess()
+    {
+        byte[][] testData =
+        [
+            [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+            [99, 100, 90, 84, 35, 31],
+            [10, 9, 8, 7, 6, 5, 4, 3, 2, 1],
+            [85, 13, 85, 12, 42, 73, 13, 74, 13, 75, 31, 58]
+        ];
+
+        for (int i = 0; i < testData.Length; i++)
+        {
+            for (int j = 0; j < testData.Length; j++)
+            {
+                BytesHelper.Equals(testData[i], testData[j]).Should().Be(i == j);
+            }
+        }
+    }
 }

--- a/tests/Application/Laminar.Domain.UnitTests/Helpers.UnitTests/BytesHelperTests.cs
+++ b/tests/Application/Laminar.Domain.UnitTests/Helpers.UnitTests/BytesHelperTests.cs
@@ -7,12 +7,13 @@ public class BytesHelperTests
     [Fact]
     public void ShouldMatchSuccess()
     {
-        byte[][] testData =
+        byte[]?[] testData =
         [
             [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
             [99, 100, 90, 84, 35, 31],
             [10, 9, 8, 7, 6, 5, 4, 3, 2, 1],
-            [85, 13, 85, 12, 42, 73, 13, 74, 13, 75, 31, 58]
+            [85, 13, 85, 12, 42, 73, 13, 74, 13, 75, 31, 58],
+            null
         ];
 
         for (int i = 0; i < testData.Length; i++)

--- a/tests/Application/Laminar.Domain.UnitTests/Laminar.Domain.UnitTests.csproj
+++ b/tests/Application/Laminar.Domain.UnitTests/Laminar.Domain.UnitTests.csproj
@@ -2,25 +2,8 @@
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
-
-    <IsPackable>false</IsPackable>
-
-    <LangVersion>default</LangVersion>
   </PropertyGroup>
-
-  <ItemGroup>
-    <PackageReference Include="FluentAssertions"/>
-    <PackageReference Include="Microsoft.NET.Test.Sdk"/>
-    <PackageReference Include="NSubstitute"/>
-    <PackageReference Include="xunit"/>
-    <PackageReference Include="xunit.runner.visualstudio">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
-  </ItemGroup>
-
+  
   <ItemGroup>
     <ProjectReference Include="..\..\..\src\Application\Laminar.Domain\Laminar.Domain.csproj" />
   </ItemGroup>

--- a/tests/Application/Laminar.Domain.UnitTests/Notification.UnitTests/FlattenedObservableTreeTests.cs
+++ b/tests/Application/Laminar.Domain.UnitTests/Notification.UnitTests/FlattenedObservableTreeTests.cs
@@ -1,8 +1,6 @@
 ﻿using System.Collections.ObjectModel;
 using System.Collections.Specialized;
-using FluentAssertions;
 using Laminar.Domain.Notification;
-using Xunit;
 using static Laminar.Domain.UnitTests.TestUtils;
 
 namespace Laminar.Domain.UnitTests.Notification.UnitTests;

--- a/tests/Application/Laminar.Domain.UnitTests/Notification.UnitTests/MappedObservableCollectionTests.cs
+++ b/tests/Application/Laminar.Domain.UnitTests/Notification.UnitTests/MappedObservableCollectionTests.cs
@@ -1,9 +1,6 @@
 using System.Collections.ObjectModel;
 using System.Collections.Specialized;
-using FluentAssertions;
 using Laminar.Domain.Notification;
-using NSubstitute;
-using Xunit;
 using static Laminar.Domain.UnitTests.TestUtils;
 
 namespace Laminar.Domain.UnitTests.Notification.UnitTests;

--- a/tests/Application/Laminar.Domain.UnitTests/Usings.cs
+++ b/tests/Application/Laminar.Domain.UnitTests/Usings.cs
@@ -1,2 +1,0 @@
-global using FluentAssertions;
-global using Xunit;

--- a/tests/Application/Laminar.Implementation.UnitTests/Laminar.Implementation.UnitTests.csproj
+++ b/tests/Application/Laminar.Implementation.UnitTests/Laminar.Implementation.UnitTests.csproj
@@ -2,24 +2,7 @@
 
     <PropertyGroup>
         <TargetFramework>net10.0</TargetFramework>
-        <IsPackable>false</IsPackable>
-        <IsTestProject>true</IsTestProject>
     </PropertyGroup>
-
-    <ItemGroup>
-        <PackageReference Include="FluentAssertions"/>
-        <PackageReference Include="Microsoft.NET.Test.Sdk"/>
-        <PackageReference Include="NSubstitute"/>
-        <PackageReference Include="xunit"/>
-        <PackageReference Include="xunit.runner.visualstudio">
-          <PrivateAssets>all</PrivateAssets>
-          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-        </PackageReference>
-    </ItemGroup>
-
-    <ItemGroup>
-        <Using Include="Xunit"/>
-    </ItemGroup>
 
     <ItemGroup>
       <ProjectReference Include="..\..\..\src\Application\Laminar.Implementation\Laminar.Implementation.csproj" />

--- a/tests/Application/Laminar.Implementation.UnitTests/Storage.UnitTests/IO.UnitTests/FileContentsTests.cs
+++ b/tests/Application/Laminar.Implementation.UnitTests/Storage.UnitTests/IO.UnitTests/FileContentsTests.cs
@@ -1,9 +1,7 @@
-using FluentAssertions;
 using Laminar.Contracts.Storage.IO;
 using Laminar.Domain.ValueObjects;
 using Laminar.Implementation.Storage.IO;
 using Microsoft.Extensions.Logging;
-using NSubstitute;
 
 namespace Laminar.Implementation.UnitTests.Storage.UnitTests.IO.UnitTests;
 
@@ -16,14 +14,14 @@ public class FileContentsTests
     private readonly ILogger<FileContents> _logger = Substitute.For<ILogger<FileContents>>();
     
     [Fact]
-    public void ShouldUpdateContents_WhenContentsSet()
+    public async Task ShouldUpdateContents_WhenContentsSet()
     {
         byte[] initialFileContents = [1, 2, 3, 4, 5];
         byte[] newFileContents = [6, 7, 8, 9, 10];
 
         var mockFileWatcher = Substitute.For<IFileWatcher>();
         var mockFileSystem = Substitute.For<IFileSystem>();
-        mockFileSystem.ReadBytes(FilePath).Returns(initialFileContents);
+        mockFileSystem.ReadBytesAsync(FilePath).Returns(initialFileContents);
         mockFileSystem.CreateFileWatcher(Arg.Any<FileSystemPath>(), Arg.Any<string>()).Returns(mockFileWatcher);
         mockFileSystem.Exists(FilePath).Returns(true);
         
@@ -31,23 +29,22 @@ public class FileContentsTests
         using var mon = sut.Monitor();
 
         sut.Contents = newFileContents;
-        sut.CheckAccess();
-        
-        mockFileSystem.Received(1).WriteBytes(FilePath, newFileContents, Arg.Any<CancellationToken>());
+
+        await sut.WaitForPendingOperations();
+        await mockFileSystem.Received(1).WriteBytes(FilePath, newFileContents, Arg.Any<CancellationToken>());
         mon.Should().Raise(nameof(IFileContents.ContentsChanged));
         Assert.Equal(newFileContents, sut.Contents);
     }
     
-    // TODO: This test fails randomly because of thread handling randomness in FileContents. That class needs a consistency pass
     [Fact]
-    public void ShouldNotReadFile_WhenContentsSet()
+    public async Task ShouldNotReadFile_WhenContentsSet()
     {
         byte[] initialFileContents = [1, 2, 3, 4, 5];
         byte[] newFileContents = [6, 7, 8, 9, 10];
     
         var mockFileWatcher = Substitute.For<IFileWatcher>();
         var mockFileSystem = Substitute.For<IFileSystem>();
-        mockFileSystem.ReadBytes(FilePath).Returns(initialFileContents);
+        mockFileSystem.ReadBytesAsync(FilePath, Arg.Any<CancellationToken>()).Returns(initialFileContents);
         mockFileSystem.CreateFileWatcher(Arg.Any<FileSystemPath>(), Arg.Any<string>()).Returns(mockFileWatcher);
         mockFileSystem.Exists(FilePath).Returns(true);
         
@@ -55,15 +52,16 @@ public class FileContentsTests
         using var mon = sut.Monitor();
     
         sut.Contents = newFileContents;
+        mockFileSystem.ReadBytesAsync(FilePath, Arg.Any<CancellationToken>()).Returns(newFileContents);
         mockFileWatcher.Changed += Raise.Event<FileSystemEventHandler>(new FileSystemEventArgs(WatcherChangeTypes.Changed, FileDirectory.ToString(), FileName));
-    
-        sut.CheckAccess();
+
+        await sut.WaitForPendingOperations();
         
-        mockFileSystem.Received(1).ReadBytes(FilePath);
+        mon.Should().Raise(nameof(IFileContents.ContentsChanged)).Should().HaveCount(1);
     }
 
     [Fact]
-    public void ShouldUpdateContents_WhenFileChanged()
+    public async Task ShouldUpdateContents_WhenFileChanged()
     {
         byte[] initialFileContents = [1, 2, 3, 4, 5];
         byte[] newFileContents = [6, 7, 8, 9, 10];
@@ -71,16 +69,17 @@ public class FileContentsTests
         var mockFileWatcher = Substitute.For<IFileWatcher>();
         var mockFileSystem = Substitute.For<IFileSystem>();
         var mockFileStream = Substitute.For<IFileStream>();
-        mockFileSystem.ReadBytes(FilePath).Returns(initialFileContents);
+        mockFileSystem.ReadBytesAsync(FilePath).Returns(initialFileContents);
         mockFileSystem.CreateFileWatcher(Arg.Any<FileSystemPath>(), Arg.Any<string>()).Returns(mockFileWatcher);
         mockFileSystem.CreateFile(FilePath).Returns(mockFileStream);
         
         using var sut = new FileContents(mockFileSystem, FilePath, _logger);
         using var mon = sut.Monitor();
         
-        mockFileSystem.ReadBytes(FilePath).Returns(newFileContents);
+        mockFileSystem.ReadBytesAsync(FilePath, Arg.Any<CancellationToken>()).Returns(newFileContents);
         mockFileWatcher.Changed += Raise.Event<FileSystemEventHandler>(new FileSystemEventArgs(WatcherChangeTypes.Changed, FileDirectory.ToString(), FileName));
-        sut.CheckAccess();
+
+        await sut.WaitForPendingOperations();
         
         mon.Should().Raise(nameof(IFileContents.ContentsChanged));
         Assert.Equal(newFileContents, sut.Contents);
@@ -94,6 +93,7 @@ public class FileContentsTests
 
         var mockFileWatcher = Substitute.For<IFileWatcher>();
         var mockFileSystem = Substitute.For<IFileSystem>();
+        mockFileSystem.ReadBytesAsync(FilePath).Returns(initialFileContents);
         mockFileSystem.ReadBytes(FilePath).Returns(initialFileContents);
         mockFileSystem.CreateFileWatcher(Arg.Any<FileSystemPath>(), Arg.Any<string>()).Returns(mockFileWatcher);
         mockFileSystem.Exists(FilePath).Returns(true);
@@ -101,7 +101,7 @@ public class FileContentsTests
         using var sut = new FileContents(mockFileSystem, FilePath, _logger);
         using var mon = sut.Monitor();
         
-        mockFileSystem.ReadBytes(FilePath).Returns(newFileContents);
+        mockFileSystem.ReadBytesAsync(FilePath).Returns(newFileContents);
         mockFileWatcher.Changed += Raise.Event<FileSystemEventHandler>(new FileSystemEventArgs(WatcherChangeTypes.Changed, FileDirectory.ToString(), "another file.txt"));
         
         mon.Should().NotRaise(nameof(IFileContents.ContentsChanged));

--- a/tests/Application/Laminar.Implementation.UnitTests/Storage.UnitTests/IO.UnitTests/FileContentsTests.cs
+++ b/tests/Application/Laminar.Implementation.UnitTests/Storage.UnitTests/IO.UnitTests/FileContentsTests.cs
@@ -39,28 +39,28 @@ public class FileContentsTests
     }
     
     // TODO: This test fails randomly because of thread handling randomness in FileContents. That class needs a consistency pass
-    // [Fact]
-    // public void ShouldNotReadFile_WhenContentsSet()
-    // {
-    //     byte[] initialFileContents = [1, 2, 3, 4, 5];
-    //     byte[] newFileContents = [6, 7, 8, 9, 10];
-    //
-    //     var mockFileWatcher = Substitute.For<IFileWatcher>();
-    //     var mockFileSystem = Substitute.For<IFileSystem>();
-    //     mockFileSystem.ReadBytes(FilePath).Returns(initialFileContents);
-    //     mockFileSystem.CreateFileWatcher(Arg.Any<FileSystemPath>(), Arg.Any<string>()).Returns(mockFileWatcher);
-    //     mockFileSystem.Exists(FilePath).Returns(true);
-    //     
-    //     using var sut = new FileContents(mockFileSystem, FilePath, _logger);
-    //     using var mon = sut.Monitor();
-    //
-    //     sut.Contents = newFileContents;
-    //     mockFileWatcher.Changed += Raise.Event<FileSystemEventHandler>(new FileSystemEventArgs(WatcherChangeTypes.Changed, FileDirectory.ToString(), FileName));
-    //
-    //     sut.CheckAccess();
-    //     
-    //     mockFileSystem.Received(1).ReadBytes(FilePath);
-    // }
+    [Fact]
+    public void ShouldNotReadFile_WhenContentsSet()
+    {
+        byte[] initialFileContents = [1, 2, 3, 4, 5];
+        byte[] newFileContents = [6, 7, 8, 9, 10];
+    
+        var mockFileWatcher = Substitute.For<IFileWatcher>();
+        var mockFileSystem = Substitute.For<IFileSystem>();
+        mockFileSystem.ReadBytes(FilePath).Returns(initialFileContents);
+        mockFileSystem.CreateFileWatcher(Arg.Any<FileSystemPath>(), Arg.Any<string>()).Returns(mockFileWatcher);
+        mockFileSystem.Exists(FilePath).Returns(true);
+        
+        using var sut = new FileContents(mockFileSystem, FilePath, _logger);
+        using var mon = sut.Monitor();
+    
+        sut.Contents = newFileContents;
+        mockFileWatcher.Changed += Raise.Event<FileSystemEventHandler>(new FileSystemEventArgs(WatcherChangeTypes.Changed, FileDirectory.ToString(), FileName));
+    
+        sut.CheckAccess();
+        
+        mockFileSystem.Received(1).ReadBytes(FilePath);
+    }
 
     [Fact]
     public void ShouldUpdateContents_WhenFileChanged()

--- a/tests/Application/Laminar.Implementation.UnitTests/Storage.UnitTests/PersistentData.UnitTests/PersistentDataPointTests.cs
+++ b/tests/Application/Laminar.Implementation.UnitTests/Storage.UnitTests/PersistentData.UnitTests/PersistentDataPointTests.cs
@@ -1,11 +1,8 @@
-using FluentAssertions;
 using Laminar.Contracts.Base;
 using Laminar.Contracts.Storage.PersistentData;
-using Laminar.Domain.Exceptions;
 using Laminar.Implementation.Storage.PersistentData;
 using Laminar.PluginFramework.Serialization;
 using Microsoft.Extensions.Logging;
-using NSubstitute;
 
 namespace Laminar.Implementation.UnitTests.Storage.UnitTests.PersistentData.UnitTests;
 

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -1,0 +1,27 @@
+<Project ToolsVersion="Current" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+    <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)..\'))" />
+
+    <PropertyGroup>
+        <IsPackable>false</IsPackable>
+        <IsTestPropject>true</IsTestPropject>
+    </PropertyGroup>
+    
+    <ItemGroup>
+        <PackageReference Include="FluentAssertions"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk"/>
+        <PackageReference Include="NSubstitute"/>
+        <PackageReference Include="xunit"/>
+        <PackageReference Include="xunit.runner.visualstudio">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+    </ItemGroup>
+    
+    <ItemGroup>
+        <Using Include="Xunit"/>
+        <Using Include="FluentAssertions"/>
+        <Using Include="NSubstitute"/>
+    </ItemGroup>
+    
+</Project>

--- a/tests/PluginFramework/Laminar.PluginFramework.UnitTests/Laminar.PluginFramework.UnitTests.csproj
+++ b/tests/PluginFramework/Laminar.PluginFramework.UnitTests/Laminar.PluginFramework.UnitTests.csproj
@@ -2,23 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
-
-    <IsPackable>false</IsPackable>
-
-    <LangVersion>default</LangVersion>
   </PropertyGroup>
-
-  <ItemGroup>
-    <PackageReference Include="FluentAssertions"/>
-    <PackageReference Include="Microsoft.NET.Test.Sdk"/>
-    <PackageReference Include="xunit"/>
-    <PackageReference Include="xunit.runner.visualstudio">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
-  </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\..\..\src\PluginFramework\Laminar.PluginFramework\Laminar.PluginFramework.csproj" />

--- a/tests/PluginFramework/Laminar.PluginFramework.UnitTests/Usings.cs
+++ b/tests/PluginFramework/Laminar.PluginFramework.UnitTests/Usings.cs
@@ -1,2 +1,0 @@
-global using FluentAssertions;
-global using Xunit;


### PR DESCRIPTION
FileContents thread management and handling of repeated read/writes has been improved, all tests have been enabled again. Also includes a cleanup of testing projects